### PR TITLE
Disable SSL verification and update user element selection

### DIFF
--- a/get-tagged-photos.py
+++ b/get-tagged-photos.py
@@ -1,4 +1,4 @@
-import argparse, sys, os, time, wget, json, piexif
+import argparse, sys, os, time, wget, json, piexif, ssl
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
@@ -8,6 +8,7 @@ from datetime import datetime
 from dateutil.parser import parse
 
 def download_photos():
+    ssl._create_default_https_context = ssl._create_unverified_context
     #Prep the download folder
     folder = 'photos/'
     if not os.path.exists(folder):

--- a/get-tagged-photos.py
+++ b/get-tagged-photos.py
@@ -63,7 +63,7 @@ def main(username, password):
             print('Done!')
             break
 
-        user = wait.until(EC.presence_of_element_located((By.XPATH, '//*[@id="fbPhotoSnowliftAuthorName"]/a')))
+        user = wait.until(EC.presence_of_element_located((By.XPATH, '//*[@id="fbPhotoSnowliftAuthorName"]//a')))
         doc = {
             'fb_url': driver.current_url,
             'fb_date': wait.until(EC.presence_of_element_located((By.CLASS_NAME, "timestampContent"))).text,


### PR DESCRIPTION
@jcontini Fixes for the following two issues I noticed:
• https://github.com/jcontini/facebook-scraper/commit/60a9398ff0b531c5202e49f52c55644bc8467ebf - Image downloads were throwing the following error - `ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:833)`
• https://github.com/jcontini/facebook-scraper/commit/0bf918204ac56923879dddaf6a98a20b54956440 - User element is not always a direct child of `#fbPhotoSnowliftAuthorName`. I saw this where posts were imported from third parties such as Wordpress.